### PR TITLE
Added RStudio server supper to rro-ubuntu containe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+CONTAINER_NAME = rro-ubuntu
+PUBLISH_PORT = 8787
+DOCKER_ERROR := $(shell docker info 2>&1 | grep -i 'cannot connect\|fatal')
+MOUNT_FOLDER := "$(HOME)/Rdata"
+
+all: setup run
+		@echo "done"
+
+.PHONY: setup
+setup:
+ifneq ($(DOCKER_ERROR),)
+		@echo $(DOCKER_ERROR)
+		$(error make sure that docker is installed and running and that you have the correct rights)
+else
+		@echo "docker is running"
+endif
+
+.PHONY: clean
+clean: stop
+ifneq ("$(shell docker images --no-trunc | grep 'none')","")
+		@echo "removing old docker images (named <none>)" 
+		@docker images --no-trunc | grep 'none' | awk '{print $$3}' | xargs docker rmi -f
+else
+		@echo "no old docker images to remove"
+endif
+
+.PHONY: build
+build: clean
+		@echo "building api docker container"
+		@docker build -t $(CONTAINER_NAME) ubuntu/
+
+.PHONY: run
+run: build start
+
+.PHONY: start
+start:
+		@echo "starting docker container"
+		@CONTAINER_ID="$(shell docker run -v $(MOUNT_FOLDER):/data -p $(PUBLISH_PORT):8787 -d $(CONTAINER_NAME))"; \
+		echo $$CONTAINER_ID >> .container-id;
+
+.PHONY: stop
+stop: 
+ifneq ("$(wildcard .container-id)","")
+		@echo "stopping api docker containers" 
+		-cat .container-id | xargs docker stop;
+		@echo "removing docker container"
+		-cat .container-id | xargs docker rm; \
+		rm .container-id;
+else
+		@echo "no docker container to stop"
+endif

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Check if docker is running:
 
     make setup
 
-To build and run the app do
+To build and run the container do
 
     make run
 
-this will build the app and start it. The first time you do this it might take a while, as docker needs to download some base images. 
+this will build the container and starts it. The first time you do this it might take a while, as docker needs to download some base images. 
 
-If you only want to build app and not yet run it, use the
+If you only want to build the container and not yet run it, use the
 
     make build
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,36 @@ This repo currently contains a Docker file for Revolution R Open on Ubuntu 14.04
 For more information please visit the MRAN web site:  
 http://mran.revolutionanalytics.com/open
 
+# Installation
+Check if docker is running:
 
-TODO:
-Add CentOS Docker files
+    make setup
+
+To build and run the app do
+
+    make run
+
+this will build the app and start it. The first time you do this it might take a while, as docker needs to download some base images. 
+
+If you only want to build app and not yet run it, use the
+
+    make build
+
+command.
+
+# Usage
+Once the container is build it can be quickly started and stopped thourgh the
+
+    make start
+
+and
+
+    make stop
+
+commands.
+
+RStudio server can now be reached on **http://localhost:8787** (note: on MacOS localhost needs to be replaced with de boot2docker ip), to login use **login:docker** and **password:docker**.
+
+The default directory that is shared with the container is **$HOME/Rdata**.
+
+The port settings and shared directory can be modified in the Makefile. 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and
 
 commands.
 
-RStudio server can now be reached on **http://localhost:8787** (note: on MacOS localhost needs to be replaced with de boot2docker ip), to login use **login:docker** and **password:docker**.
+RStudio server can now be reached on **http://localhost:8787** (note: on MacOS localhost needs to be replaced with de boot2docker ip), to login use **login: docker** and **password: docker**.
 
 The default directory that is shared with the container is **$HOME/Rdata**.
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -29,18 +29,21 @@ RUN apt-get update -qq \
     git \
     g++ \
     libcurl4-openssl-dev \
-    curl
+    curl \
+    gdebi-core \
+    libapparmor1 \
+    supervisor
 
 ## Install Revolution R Open 8.0 Beta
 RUN cd /tmp \
-&& wget http://mran.revolutionanalytics.com/install/RRO-8.0-Beta-Ubuntu-14.04.x86_64.tar.gz \
-&&  tar -xzf RRO-8.0-Beta-Ubuntu-14.04.x86_64.tar.gz \
-&& ./install.sh
+    && wget http://mran.revolutionanalytics.com/install/RRO-8.0-Beta-Ubuntu-14.04.x86_64.tar.gz \
+    && tar -xzf RRO-8.0-Beta-Ubuntu-14.04.x86_64.tar.gz \
+    && ./install.sh
 
 ## This is just to set a sane container wide default and is not required
 RUN mkdir /etc/R \
-&& touch /etc/R/Rprofile.site \
-&& echo 'options(repos = list(CRAN = "http://cran.revolutionanalytics.com/"))' >> /etc/R/Rprofile.site
+    && touch /etc/R/Rprofile.site \
+    && echo 'options(repos = list(CRAN = "http://cran.revolutionanalytics.com/"))' >> /etc/R/Rprofile.site
 
 ## By default the `checkpoint` R package is in RRO.
 ## Use the command below to load it into your R session
@@ -48,16 +51,35 @@ RUN mkdir /etc/R \
 ## Select a snapshot date in the past, as in the example below
 ## checkpoint("2014-11-10")
 
+## Install RStudio server
+RUN cd /tmp \
+    && wget http://download2.rstudio.org/rstudio-server-0.98.1091-amd64.deb -O studio-server.deb \
+    && gdebi -qn studio-server.deb
+
 ## Set a default user. Available via runtime flag `--user docker` 
 ## Add user to 'staff' group, granting them write privileges to /usr/local/lib/R/site.library
 ## User should also have & own a home directory (for rstudio or linked volumes to work properly). (could use adduser to create this automatically instead)
 RUN useradd docker \
-&& mkdir /home/docker \
-&& chown docker:docker /home/docker \
-&& addgroup docker staff
+    && mkdir /home/docker \
+    && chown docker:docker /home/docker \
+    && addgroup docker staff \
+    && echo "docker:docker" | chpasswd
 
 ## Configure default locale
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
-&& locale-gen en_US.utf8 \
-&& /usr/sbin/update-locale LANG=en_US.UTF-8
+    && locale-gen en_US.utf8 \
+    && /usr/sbin/update-locale LANG=en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
+
+## User config and supervisord for persistant RStudio session
+COPY ./conf/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+RUN mkdir -p /var/log/supervisor \
+    && chgrp staff /var/log/supervisor \
+    && chmod g+w /var/log/supervisor \
+    && chgrp staff /etc/supervisor/conf.d/supervisord.conf
+
+# Exposing default RStudio server port 8787
+EXPOSE 8787
+
+# Starting RStudio server via supervisor
+CMD ["/usr/bin/supervisord"]

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,4 +1,10 @@
 ## Example Usage:
+
+## To run RStudio server
+## docker run -v $HOME/Rdata:/data -p 8787:8787 -d rro-ubuntu
+## login: docker password: docker
+#
+# To run R
 ## docker run -v $HOME/Rdata:/data -it revolutionanalytics/rro-ubuntu R
 
 ## Adapted from:

--- a/ubuntu/conf/supervisord.conf
+++ b/ubuntu/conf/supervisord.conf
@@ -1,0 +1,10 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/tmp/supervisord.pid
+
+[program:rserver]
+command=/usr/lib/rstudio-server/bin/rserver
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+user=root


### PR DESCRIPTION
Hi cmosetick,

I do not know if you are interested, however I added RStudio server functionality to your docker container. 

It is quite straightforward to use. Just start the container, either using the Makefile or through "docker run -v $HOME/Rdata:/data -p 8787:8787 -d rro-ubuntu" (after having build the container of course). You can now reach RStudio server on http://localhost:8787 and login with login: docker and password: docker.

Cheers,

Stijn

